### PR TITLE
fixup! SystemUI: Allow Wi-Fi/cell tiles to co-exist with provider model

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/MobileSignalController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/MobileSignalController.java
@@ -395,9 +395,11 @@ public class MobileSignalController extends SignalController<MobileState, Mobile
         IconState qsIcon = null;
         CharSequence qsDescription = null;
 
-        boolean pm = mProviderModelSetting || mProviderModelBehavior;
         if (mCurrentState.dataSim) {
-            // If using provider model behavior, only show QS icons if the state is also default
+            if (mProviderModelBehavior) {
+                return new QsInfo(qsTypeIcon, qsIcon, qsDescription);
+            }
+
             if (mCurrentState.showQuickSettingsRatIcon() || mConfig.alwaysShowDataRatIcon) {
                 qsTypeIcon = dataTypeIcon;
             }
@@ -421,7 +423,7 @@ public class MobileSignalController extends SignalController<MobileState, Mobile
 
         if (mProviderModelBehavior) {
             boolean showDataIconStatusBar = (mCurrentState.dataConnected || dataDisabled)
-                    && mCurrentState.dataSim;
+                    && (mCurrentState.dataSim && mCurrentState.isDefault);
             typeIcon =
                     (showDataIconStatusBar || mConfig.alwaysShowDataRatIcon) ? dataTypeIcon : 0;
             showDataIconStatusBar |= mCurrentState.roaming;

--- a/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/SignalCallback.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/SignalCallback.kt
@@ -123,7 +123,7 @@ data class WifiIndicators(
     @JvmField val description: String?,
     @JvmField val isTransient: Boolean,
     @JvmField val statusLabel: String?,
-    @JvmField val isDefault: Boolean,
+    @JvmField val isDefault: Boolean
 ) {
     override fun toString(): String {
         return StringBuilder("WifiIndicators[")
@@ -135,6 +135,7 @@ data class WifiIndicators(
                 .append(",qsDescription=").append(description)
                 .append(",isTransient=").append(isTransient)
                 .append(",statusLabel=").append(statusLabel)
+                .append(",isDefault=").append(isDefault)
                 .append(']').toString()
     }
 }
@@ -153,7 +154,7 @@ data class MobileDataIndicators(
     @JvmField val subId: Int,
     @JvmField val roaming: Boolean,
     @JvmField val showTriangle: Boolean,
-    @JvmField val isDefault: Boolean,
+    @JvmField val isDefault: Boolean
 ) {
     override fun toString(): String {
         return java.lang.StringBuilder("MobileDataIndicators[")
@@ -169,6 +170,7 @@ data class MobileDataIndicators(
                 .append(",subId=").append(subId)
                 .append(",roaming=").append(roaming)
                 .append(",showTriangle=").append(showTriangle)
+                .append(",isDefault=").append(isDefault)
                 .append(']').toString()
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/WifiSignalController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/WifiSignalController.java
@@ -83,7 +83,9 @@ public class WifiSignalController extends SignalController<WifiState, IconGroup>
     @Override
     public void notifyListeners(SignalCallback callback) {
         if (mCurrentState.isCarrierMerged) {
-            notifyListenersForCarrierWifi(callback);
+            if (mCurrentState.isDefault || !mNetworkController.isRadioOn()) {
+                notifyListenersForCarrierWifi(callback);
+            }
         } else {
             notifyListenersForNonCarrierWifi(callback);
         }
@@ -103,37 +105,20 @@ public class WifiSignalController extends SignalController<WifiState, IconGroup>
         if (mCurrentState.inetCondition == 0) {
             contentDescription += ("," + mContext.getString(R.string.data_connection_no_internet));
         }
-        if (mProviderModelSetting) {
-            IconState statusIcon = new IconState(
-                    wifiVisible, getCurrentIconId(), contentDescription);
-            IconState qsIcon = new IconState(mCurrentState.connected,
-                    mWifiTracker.isCaptivePortal ? R.drawable.ic_qs_wifi_disconnected
-                            : getQsCurrentIconId(), contentDescription);
-            boolean isDefault = mCurrentState.isDefault || (!mNetworkController.isRadioOn()
-                    && !mNetworkController.isEthernetDefault());
-            WifiIndicators wifiIndicators = new WifiIndicators(
-                    mCurrentState.enabled, statusIcon, qsIcon,
-                    ssidPresent && mCurrentState.activityIn,
-                    ssidPresent && mCurrentState.activityOut,
-                    wifiDesc, mCurrentState.isTransient, mCurrentState.statusLabel,
-                    isDefault
-            );
-            callback.setWifiIndicators(wifiIndicators);
-        } else {
-            IconState statusIcon = new IconState(
-                    wifiVisible, getCurrentIconId(), contentDescription);
-            IconState qsIcon = new IconState(mCurrentState.connected,
-                    mWifiTracker.isCaptivePortal ? R.drawable.ic_qs_wifi_disconnected
-                            : getQsCurrentIconId(), contentDescription);
-            WifiIndicators wifiIndicators = new WifiIndicators(
-                    mCurrentState.enabled, statusIcon, qsIcon,
-                    ssidPresent && mCurrentState.activityIn,
-                    ssidPresent && mCurrentState.activityOut,
-                    wifiDesc, mCurrentState.isTransient, mCurrentState.statusLabel,
-                    false
-            );
-            callback.setWifiIndicators(wifiIndicators);
-        }
+        IconState statusIcon = new IconState(
+                wifiVisible, getCurrentIconId(), contentDescription);
+        IconState qsIcon = new IconState(mCurrentState.connected,
+                mWifiTracker.isCaptivePortal ? R.drawable.ic_qs_wifi_disconnected
+                        : getQsCurrentIconId(), contentDescription);
+        boolean isDefault = mCurrentState.isDefault || (!mNetworkController.isRadioOn()
+                && !mNetworkController.isEthernetDefault());
+        WifiIndicators wifiIndicators = new WifiIndicators(
+                mCurrentState.enabled, statusIcon, qsIcon,
+                ssidPresent && mCurrentState.activityIn,
+                ssidPresent && mCurrentState.activityOut,
+                wifiDesc, mCurrentState.isTransient, mCurrentState.statusLabel, isDefault
+        );
+        callback.setWifiIndicators(wifiIndicators);
     }
 
     private void notifyListenersForCarrierWifi(SignalCallback callback) {
@@ -146,22 +131,26 @@ public class WifiSignalController extends SignalController<WifiState, IconGroup>
         if (mCurrentState.inetCondition == 0) {
             dataContentDescription = mContext.getString(R.string.data_connection_no_internet);
         }
-        boolean sbVisible = mCurrentState.enabled && mCurrentState.connected;
+        boolean sbVisible = mCurrentState.enabled && mCurrentState.connected
+                && mCurrentState.isDefault;
         IconState statusIcon =
                 new IconState(sbVisible, getCurrentIconIdForCarrierWifi(), contentDescription);
         int typeIcon = sbVisible ? icons.dataType : 0;
-        int qsTypeIcon = icons.dataType;
-        IconState qsIcon = new IconState(mCurrentState.connected, getQsCurrentIconIdForCarrierWifi(),
-                contentDescription);
+        int qsTypeIcon = 0;
+        IconState qsIcon = null;
+        if (sbVisible) {
+            qsTypeIcon = icons.dataType;
+            qsIcon = new IconState(mCurrentState.connected, getQsCurrentIconIdForCarrierWifi(),
+                    contentDescription);
+        }
         CharSequence description =
                 mNetworkController.getNetworkNameForCarrierWiFi(mCurrentState.subId);
-        boolean isDefault = mCurrentState.isDefault || !mNetworkController.isRadioOn();
         MobileDataIndicators mobileDataIndicators = new MobileDataIndicators(
                 statusIcon, qsIcon, typeIcon, qsTypeIcon,
                 mCurrentState.activityIn, mCurrentState.activityOut, dataContentDescription,
                 dataContentDescriptionHtml, description,
                 mCurrentState.subId, /* roaming= */ false, /* showTriangle= */ true,
-                isDefault
+                /* isDefault= */ qsIcon != null
         );
         callback.setMobileDataIndicators(mobileDataIndicators);
     }


### PR DESCRIPTION
Revert and re-pick from LineageOS[1] to fix broken internet tile.

Squashed:

Revert "SystemUI: Allow Wi-Fi/cell tiles to co-exist with provider model"

This reverts commit 0469eb5d50b19a1a1ae25b4e6ac2dc256a31bf60.

SystemUI: Allow Wi-Fi/cell tiles to co-exist with provider model

The dedicated Wi-Fi/cellular data QS tiles are partially working now
that we've exposed them in the list of tile options, but they're very
buggy and somewhat broken when the provider model (unified internet) is
enabled.

Allow the tiles to co-exist with InternetTile and the provider model
(including both settings_provider_model and combined signal icons) by
always including QS icons in Wi-Fi/data indicator callbacks, and add
a new flag to indicate whether they should be shown in the internet
tile.

(cdesai, mkbestas: Port to 12L)

Change-Id: I10af134b35dfabdb9275f1aca8ca8512e1db6d27

[1]: LineageOS/android_frameworks_base@05841fd
Change-Id: I321ad6507914f9776cd105e4ccae5ba695e1f4f0
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>